### PR TITLE
fix(apps): fix can not find name error

### DIFF
--- a/apps/myorg/tsconfig.json
+++ b/apps/myorg/tsconfig.json
@@ -8,9 +8,6 @@
     },
     {
       "path": "./tsconfig.spec.json"
-    },
-    {
-      "path": "./tsconfig.editor.json"
     }
   ],
   "compilerOptions": {


### PR DESCRIPTION
Fix Can not find name error of app.component.spec.ts