### PR TITLE
fix/input-label-width

### DIFF
--- a/libs/feature-login/src/lib/components/login-form/login-form.component.html
+++ b/libs/feature-login/src/lib/components/login-form/login-form.component.html
@@ -12,7 +12,6 @@
   <form [formGroup]="loginFormGroup">
     <div class="flex flex-col items-center">
       <mat-form-field appearance="outline" class="w-80 my-6">
-        <mat-label>ログインIDを入力</mat-label>
         <input
           matInput
           type="text"
@@ -27,7 +26,6 @@
         }}</mat-error>
       </mat-form-field>
       <mat-form-field appearance="outline" class="w-80 my-6">
-        <mat-label>パスワードを入力</mat-label>
         <input
           matInput
           type="password"


### PR DESCRIPTION
focusすると、テキストボックスの中に枠線が表示されるのが邪魔
どうしても解決できず、labelを削除することにした
![Screenshot 2023-01-15 at 10 33 57](https://user-images.githubusercontent.com/1982567/212504741-5c7cac96-a44a-4f57-a7f4-23074e30ea65.png)
