### PR TITLE
feat(libs/myorg/shared): use environment in libs

### DIFF
--- a/apps/myorg/src/app/app.module.ts
+++ b/apps/myorg/src/app/app.module.ts
@@ -3,7 +3,9 @@ import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
+import { MYORG_APP_CONFIG } from '@myorg/myorg-config';
 import { CookieService } from 'ngx-cookie-service';
+import { environment } from '../environments/environment';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 
@@ -17,7 +19,10 @@ import { AppComponent } from './app.component';
     HttpClientModule,
   ],
   bootstrap: [AppComponent],
-  providers: [CookieService],
+  providers: [
+    CookieService,
+    { provide: MYORG_APP_CONFIG, useValue: environment },
+  ],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class AppModule {}

--- a/libs/myorg/shared/src/index.ts
+++ b/libs/myorg/shared/src/index.ts
@@ -1,4 +1,5 @@
+export * from './lib/app-config';
 export * from './lib/models';
+export * from './lib/myorg-shared.module';
 export * from './lib/services/auth.service';
 export * from './lib/services/login.service';
-export * from './lib/myorg-shared.module';

--- a/libs/myorg/shared/src/lib/app-config/index.ts
+++ b/libs/myorg/shared/src/lib/app-config/index.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const MYORG_APP_CONFIG = new InjectionToken('Myorg Application config');

--- a/libs/myorg/shared/src/lib/models/environment.model.ts
+++ b/libs/myorg/shared/src/lib/models/environment.model.ts
@@ -1,0 +1,3 @@
+export interface Environment {
+  production: boolean;
+}

--- a/libs/myorg/shared/src/lib/models/index.ts
+++ b/libs/myorg/shared/src/lib/models/index.ts
@@ -1,2 +1,3 @@
+export * from './environment.model';
 export * from './login.model';
 export * from './request-status.model';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,7 +17,8 @@
     "paths": {
       "@myorg/myorg/feature-login": ["libs/myorg/feature-login/src/index.ts"],
       "@myorg/myorg/feature-top": ["libs/myorg/feature-top/src/index.ts"],
-      "@myorg/myorg/shared": ["libs/myorg/shared/src/index.ts"]
+      "@myorg/myorg/shared": ["libs/myorg/shared/src/index.ts"],
+      "@myorg/myorg-config": ["libs/myorg/shared/src/lib/app-config/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
environment.tsをlibsで使えるようにした。

使いたい箇所で下記のようにして使う
```
import { Environment, MYORG_APP_CONFIG } from '@myorg/myorg/shared';

  constructor(@Inject(MYORG_APP_CONFIG) config: Environment) {
    console.log('environment -> ', config);
  }
```