### PR TITLE
feat: settings ignore deploy folders and files

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,6 +1,4 @@
-e2e
 node_modules
-src
 ^(.*/)?\..*$
 ^(.*/)?.*\.json$
 ^(.*/)?.*\.md$
@@ -10,3 +8,14 @@ src
 .nx
 .pnpm-store
 .vscode
+.DS_Store
+.git
+apps
+cypress
+libs
+tools
+*.config.ts
+*.json
+*.md
+*.yaml
+*.log


### PR DESCRIPTION
デプロイに1分55秒かかっていて、もう少し早くしたい
余計なものをデプロイ対象にしてるせいで時間がかかってると推測
![Screenshot 2024-02-15 at 9 06 35](https://github.com/ksakae1216/angular2022/assets/1982567/52845bc5-5dc3-44e8-8b0f-96f293f97dcd)
