### PR TITLE
fix: display deploy page

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -10,7 +10,6 @@ node_modules
 .vscode
 .DS_Store
 .git
-apps
 cypress
 libs
 tools


### PR DESCRIPTION
#146 で不要なファイルを除外したんだけど、appディレクトリを除外したら、デプロイしたURLに画面が表示されなくなった(https://146-dot-static-retina-404402.de.r.appspot.com)

ビルドしたdistディレクトリさえあれば大丈夫だと思ってた